### PR TITLE
Improvements, POSIX compliance, misc

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Download and runs the latest build of Chromium
 
 Download a specific revision
 
-    $ export REVISION=492595
-    $ ./update-and-run.sh
+    $ ./update-and-run.sh 492595
 
 The same use is possible with ./update.sh

--- a/run.sh
+++ b/run.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#!/usr/bin/env sh
 
 BASEDIR=$(dirname $(realpath $0))
 

--- a/update-and-run.sh
+++ b/update-and-run.sh
@@ -1,3 +1,3 @@
-#! /bin/bash
+#!/usr/bin/env sh
 cd $(dirname $0)
 ./update.sh && ./run.sh $*

--- a/update.sh
+++ b/update.sh
@@ -1,35 +1,56 @@
-#! /bin/bash
+#!/usr/bin/env sh
+
+command -v unzip >/dev/null 2>&1 || { printf "Error: you need to install \"unzip\" first!\n"; exit 1; }
 
 cd $(dirname $0)
 
-LASTCHANGE_URL="https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2FLAST_CHANGE?alt=media"
+case $(uname -m) in
+"x86_64")
+  ARCH="Linux_x64"
+  ;;
+"amd64")
+  ARCH="Linux_x64"
+  ;;
+arm*)
+  ARCH="Arm"
+  ;;
+*)
+  ARCH="Linux"
+  ;;
+esac
 
-if [ -z "$REVISION" ]; then
- REVISION=$(curl -s -S $LASTCHANGE_URL)
+BASE_URL="https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/$ARCH"
 
-  echo "latest revision is $REVISION"
+LASTCHANGE_URL="$BASE_URL%2FLAST_CHANGE?alt=media"
+
+if [ -z "$1" ]; then
+  REVISION=$(curl -s -S $LASTCHANGE_URL)
+  printf "Latest revision is $REVISION\n"
 else
-  echo "Using given revision $REVISION as latest revision"
+  REVISION=$1
+  printf "Using given revision $REVISION as latest revision\n"
 fi
 
 if [ -d $REVISION ] ; then
-  echo "already have latest version"
-  exit
+  printf "You already have the latest version\n"
+  exit 0
 fi
 
-ZIP_URL="https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Linux_x64%2F$REVISION%2Fchrome-linux.zip?alt=media"
+ZIP_URL="$BASE_URL%2F$REVISION%2Fchrome-linux.zip?alt=media"
 
 ZIP_FILE="${REVISION}-chrome-linux.zip"
 
-echo "fetching $ZIP_URL"
+printf "Fetching $ZIP_URL\n"
 
 rm -rf $REVISION
 mkdir $REVISION
-pushd $REVISION
+cd $REVISION
 curl -# $ZIP_URL > $ZIP_FILE
-echo "unzipping.."
-unzip $ZIP_FILE
-popd
+printf "Unzipping...\n"
+unzip -q $ZIP_FILE
+cd ..
 ln -fsT $REVISION/chrome-linux/ ./latest
+printf "Changing owner and permissions for chrome_sandbox (requires privileges):\n"
 sudo chown root:root ./latest/chrome_sandbox
 sudo chmod 4755 ./latest/chrome_sandbox
+printf "Script completed successfully\n"

--- a/update.sh
+++ b/update.sh
@@ -48,6 +48,7 @@ cd $REVISION
 curl -# $ZIP_URL > $ZIP_FILE
 printf "Unzipping...\n"
 unzip -q $ZIP_FILE
+[ $? -ne 0 ] && { printf "Error: not a valid zip file\n" ; exit 1; }
 cd ..
 ln -fsT $REVISION/chrome-linux/ ./latest
 printf "Changing owner and permissions for chrome_sandbox (requires privileges):\n"


### PR DESCRIPTION
A summary of all changes:
* shebang "/usr/bin/env sh" : sh instead of bash. The script is now POSIX compliant, if a user has dash as default will be faster. First shell in user PATH will be used.
* we need unzip installed, added a check for it.
* added support for x86 and arm.
* Avoid exporting a REVISION variable. Instead input a parameter (README edited accordingly).
* used cd instead of pushd/popd: they are bash-only and totally unnecessary here
* exit message if parameter is invalid (downloads and invalid zip)
* other minor edits